### PR TITLE
Font smoothing

### DIFF
--- a/src/.theme/style.fx.css
+++ b/src/.theme/style.fx.css
@@ -1,5 +1,9 @@
 @import 'style_light.fx.css';
 
+.text {
+    -fx-font-smoothing-type: gray;
+}
+
 .mtitle {
     -fx-font-family: "Roboto Medium";
     -fx-font-size: 18;


### PR DESCRIPTION
JavaFX has a bad font smoothing by default, if we wanna fix this we need to force it to work good.

Implementation:
```css
.text {
    -fx-font-smoothing-type: gray;
}
```
to styles.